### PR TITLE
Call cuda() on loaded checkpoints

### DIFF
--- a/models/init.lua
+++ b/models/init.lua
@@ -22,11 +22,11 @@ function M.setup(opt, checkpoint)
       local modelPath = paths.concat(opt.resume, checkpoint.modelFile)
       assert(paths.filep(modelPath), 'Saved model not found: ' .. modelPath)
       print('=> Resuming model from ' .. modelPath)
-      model = torch.load(modelPath)
+      model = torch.load(modelPath):cuda()
    elseif opt.retrain ~= 'none' then
       assert(paths.filep(opt.retrain), 'File not found: ' .. opt.retrain)
       print('Loading model from file: ' .. opt.retrain)
-      model = torch.load(opt.retrain)
+      model = torch.load(opt.retrain):cuda()
    else
       print('=> Creating model from file: models/' .. opt.netType .. '.lua')
       model = require('models/' .. opt.netType)(opt)


### PR DESCRIPTION
Checkpoints are now the CPU version of the model, so we need to call
:cuda() on the model before training.

Fixes #88
